### PR TITLE
#267: Configure mypy SQLAlchemy plugin

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -73,6 +73,7 @@ keep-runtime-typing = true
 [tool.mypy]
 strict = true
 exclude = ["venv", ".venv", "alembic", "legacy"]
+plugins = ["sqlalchemy.ext.mypy.plugin"]
 
 [tool.coverage.run]
 source = ["app"]


### PR DESCRIPTION
## Summary

Configure mypy to use the SQLAlchemy plugin for improved type inference across database operations.

## Changes

### Tooling

- Add SQLAlchemy plugin to mypy configuration
- Enables better type inference for database queries and relationships