### PR TITLE
implementation of Product Delete API

### DIFF
--- a/backend/app/controllers/products.py
+++ b/backend/app/controllers/products.py
@@ -2,12 +2,15 @@
 
 from uuid import UUID
 
+from aiobotocore.client import AioBaseClient  # type: ignore[import-untyped]
 from pydantic import validate_call
 from sqlalchemy.orm import Session
 from sqlmodel import select
 from sqlmodel.sql.expression import SelectOfScalar
 
+from app.db.models.label import Label
 from app.db.models.product import Product
+from app.storage import delete_files
 
 
 @validate_call(config={"arbitrary_types_allowed": True})
@@ -27,9 +30,40 @@ def get_products_query(
 
 
 @validate_call(config={"arbitrary_types_allowed": True})
+def get_product_by_id(
+    session: Session,
+    product_id: UUID | str,
+) -> Product | None:
+    """Get product by ID."""
+    stmt = select(Product).where(Product.id == product_id)
+    result = session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+@validate_call(config={"arbitrary_types_allowed": True})
 def create_product(session: Session, product: Product) -> Product:
     """Create a new product."""
     session.add(product)
     session.flush()
     session.refresh(product)
     return product
+
+
+@validate_call(config={"arbitrary_types_allowed": True})
+async def delete_product(
+    session: Session, product_id: UUID | str, s3_client: AioBaseClient
+) -> bool:
+    """Delete a product"""
+    if not (product := get_product_by_id(session=session, product_id=product_id)):
+        return False
+
+    stm = select(Label).where(Label.product_id == product.id)
+    label = session.scalar(stm)
+    if label:
+        file_paths = [img.file_path for img in label.images]
+        if file_paths:
+            await delete_files(client=s3_client, file_paths=file_paths)
+
+    session.delete(product)
+    session.flush()
+    return True

--- a/backend/app/routes/products.py
+++ b/backend/app/routes/products.py
@@ -12,8 +12,11 @@ from app.dependencies import (
     LimitOffsetParamsDep,
     ProductRegistrationNumberUniqueDep,
     ProductTypeQueryDep,
+    S3ClientDep,
     SessionDep,
 )
+from app.exceptions import ProductNotFound
+from app.schemas.message import Message
 from app.schemas.product import ProductPublic
 
 router = APIRouter(prefix="/products", tags=["products"])
@@ -55,3 +58,19 @@ async def create_product(
         session=session, product=product
     )
     return created_product  # type: ignore[return-value]
+
+
+@router.delete("/{product_id}", response_model=Message, status_code=200)
+async def delete_product(
+    *,
+    session: SessionDep,
+    _: CurrentUser,
+    product_id: str,
+    s3_client: S3ClientDep,
+) -> Message:
+    """Delete a product"""
+    if not await product_controller.delete_product(
+        session=session, product_id=product_id, s3_client=s3_client
+    ):
+        raise ProductNotFound()
+    return Message(message="Product deleted successfully")

--- a/backend/tests/test_routes/test_products.py
+++ b/backend/tests/test_routes/test_products.py
@@ -1,14 +1,25 @@
 """Product route tests."""
 
 import pytest
+from botocore.exceptions import ClientError
 from fastapi.testclient import TestClient
+from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.config import settings
+from app.db.models.label import Label
+from app.db.models.label_image import LabelImage
+from tests.factories.label import LabelFactory
+from tests.factories.label_data import LabelDataFactory
+from tests.factories.label_image import LabelImageFactory
 from tests.factories.product import ProductFactory
 from tests.factories.product_type import ProductTypeFactory
 from tests.factories.user import UserFactory
-from tests.utils.user import authentication_token_from_email
+from tests.utils.user import (
+    authentication_token_from_email,
+    authentication_token_from_email_async,
+)
 
 
 @pytest.mark.usefixtures("override_dependencies")
@@ -509,3 +520,180 @@ class TestProductCreate:
             json=data_fertilizer,
         )
         assert response1.status_code == 201
+
+
+@pytest.mark.usefixtures("override_dependencies")
+class TestDeleteProduct:
+    """Tests for deleting products endpoint."""
+
+    def test_delete_product_success(
+        self,
+        client: TestClient,
+        db: Session,
+    ) -> None:
+        """Test successful product deletion."""
+        user = UserFactory()
+        product = ProductFactory(created_by=user)
+        headers = authentication_token_from_email(
+            client=client, email=user.email, db=db
+        )
+        product_id = str(product.id)
+        response = client.delete(
+            f"{settings.API_V1_STR}/products/{product_id}",
+            headers=headers,
+        )
+        assert response.status_code == 200
+
+        content = response.json()
+        assert content["message"] == "Product deleted successfully"
+
+    def test_product_not_found(
+        self,
+        client: TestClient,
+        db: Session,
+    ) -> None:
+        """Test deleting a non-existent product."""
+        user = UserFactory()
+        headers = authentication_token_from_email(
+            client=client, email=user.email, db=db
+        )
+        non_existent_product_id = "123e4567-e89b-12d3-a456-426614174000"
+        response = client.delete(
+            f"{settings.API_V1_STR}/products/{non_existent_product_id}",
+            headers=headers,
+        )
+        assert response.status_code == 404
+        content = response.json()
+        assert content["detail"] == "Product not found"
+
+    def test_auth_required_for_deletion(
+        self,
+        client: TestClient,
+        db: Session,
+    ) -> None:
+        """Test that authentication is required for deleting a product."""
+        user = UserFactory()
+        product = ProductFactory(created_by=user)
+        product_id = str(product.id)
+        response = client.delete(
+            f"{settings.API_V1_STR}/products/{product_id}",
+            headers={},
+        )
+        assert response.status_code == 401
+
+    def test_try_to_delete_after_already_deleted(
+        self,
+        client: TestClient,
+        db: Session,
+    ) -> None:
+        """Test deleting a product that has already been deleted."""
+        user = UserFactory()
+        product = ProductFactory(created_by=user)
+        headers = authentication_token_from_email(
+            client=client, email=user.email, db=db
+        )
+        product_id = str(product.id)
+        response1 = client.delete(
+            f"{settings.API_V1_STR}/products/{product_id}",
+            headers=headers,
+        )
+        assert response1.status_code == 200
+        response2 = client.delete(
+            f"{settings.API_V1_STR}/products/{product_id}",
+            headers=headers,
+        )
+        assert response2.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_product_delete_all_associated_data(
+        self, async_client: AsyncClient, db: Session
+    ) -> None:
+        """Test that deleting a product also deletes all associated data from database."""
+        user = UserFactory()
+        product = ProductFactory(created_by=user)
+        label = LabelFactory(created_by=user, product=product)
+        LabelDataFactory(
+            label=label,
+            registration_number="REG-12345",
+            brand_name_en="New Brand",
+            product_name_en="New Name",
+        )
+        image1 = LabelImageFactory(label=label)
+        image1_id = image1.id
+        image2 = LabelImageFactory(label=label)
+        image2_id = image2.id
+
+        headers = await authentication_token_from_email_async(
+            client=async_client, email=user.email, db=db
+        )
+        product_id = product.id
+        label_id = label.id
+
+        response = await async_client.delete(
+            f"{settings.API_V1_STR}/products/{product_id}",
+            headers=headers,
+        )
+        assert response.status_code == 200
+
+        content = response.json()
+        assert content["message"] == "Product deleted successfully"
+        db.flush()
+
+        stm = select(Label).where(Label.product_id == product_id)
+        label = db.scalar(stm)
+        assert label is None
+        stm = select(LabelImage).where(LabelImage.label_id == label_id)  # type: ignore[assignment]
+        label_images = db.scalar(stm)
+        assert label_images is None
+        assert (db.get(LabelImage, image1_id) and db.get(LabelImage, image2_id)) is None
+
+    @pytest.mark.asyncio
+    async def test_delete_product_delete_files_from_storage(
+        self, async_client: AsyncClient, db: Session, s3_client
+    ) -> None:
+        """Test that deleting a product also deletes all associated files from storage."""
+        user = UserFactory()
+        product = ProductFactory(created_by=user)
+        label = LabelFactory(created_by=user, product=product)
+        image1 = LabelImageFactory(label=label)
+        image2 = LabelImageFactory(label=label)
+
+        await s3_client.put_object(
+            Bucket=settings.STORAGE_BUCKET_NAME,
+            Key=image1.file_path,
+            Body=b"test content",
+        )
+        await s3_client.put_object(
+            Bucket=settings.STORAGE_BUCKET_NAME,
+            Key=image2.file_path,
+            Body=b"test content",
+        )
+
+        headers = await authentication_token_from_email_async(
+            client=async_client, email=user.email, db=db
+        )
+        product_id = product.id
+
+        response = await async_client.delete(
+            f"{settings.API_V1_STR}/products/{product_id}",
+            headers=headers,
+        )
+        assert response.status_code == 200
+
+        try:
+            await s3_client.head_object(
+                Bucket=settings.STORAGE_BUCKET_NAME,
+                Key=image1.file_path,
+            )
+            raise AssertionError("File should have been deleted")
+        except ClientError as e:
+            assert e.response["Error"]["Code"] in ("404", "NoSuchKey")
+        finally:
+            try:
+                await s3_client.head_object(
+                    Bucket=settings.STORAGE_BUCKET_NAME,
+                    Key=image2.file_path,
+                )
+                raise AssertionError("File should have been deleted")
+            except ClientError as e:
+                assert e.response["Error"]["Code"] in ("404", "NoSuchKey")


### PR DESCRIPTION
## Summary

Implementation of product deletion in the API, including the removal of all associated data.

## Changes

### Backend

- Implementation of route for delete product
- Add test suite and all test pass
- #### Controller Product
    - Add method to search a product with the ```product_id```
    - Add method to delete product and all associated data

