### PR TITLE
implementation to read product API

### DIFF
--- a/backend/app/controllers/products.py
+++ b/backend/app/controllers/products.py
@@ -35,6 +35,8 @@ def get_product_by_id(
     product_id: UUID | str,
 ) -> Product | None:
     """Get product by ID."""
+    if isinstance(product_id, str):
+        product_id = UUID(product_id)
     stmt = select(Product).where(Product.id == product_id)
     result = session.execute(stmt)
     return result.scalar_one_or_none()

--- a/backend/app/routes/products.py
+++ b/backend/app/routes/products.py
@@ -47,11 +47,26 @@ def read_products(
     return paginate(session, stmt, params)  # type: ignore[no-any-return, call-overload]
 
 
+@router.get("/{product_id}", response_model=ProductPublic)
+def read_product_by_id(
+    *, session: SessionDep, _: CurrentUser, product_id: str
+) -> ProductPublic:
+    """Get product by ID."""
+    if not (
+        product := product_controller.get_product_by_id(
+            session=session, product_id=product_id
+        )
+    ):
+        raise ProductNotFound()
+    return product  # type: ignore[return-value]
+
+
 @router.post("", response_model=ProductPublic, status_code=201)
 async def create_product(
     *,
     session: SessionDep,
     product: ProductRegistrationNumberUniqueDep,
+    _: CurrentUser,
 ) -> ProductPublic:
     """Create a new product."""
     created_product = product_controller.create_product(

--- a/backend/tests/test_routes/test_products.py
+++ b/backend/tests/test_routes/test_products.py
@@ -697,3 +697,68 @@ class TestDeleteProduct:
                 raise AssertionError("File should have been deleted")
             except ClientError as e:
                 assert e.response["Error"]["Code"] in ("404", "NoSuchKey")
+
+
+@pytest.mark.usefixtures("override_dependencies")
+class TestReadByIdProduct:
+    """Tests for reading product by ID endpoint."""
+
+    def test_read_product_by_id_success(
+        self,
+        client: TestClient,
+        db: Session,
+    ) -> None:
+        """Test successful reading product by ID."""
+        user = UserFactory()
+        product = ProductFactory(created_by=user)
+        headers = authentication_token_from_email(
+            client=client, email=user.email, db=db
+        )
+        product_id = str(product.id)
+        response = client.get(
+            f"{settings.API_V1_STR}/products/{product_id}",
+            headers=headers,
+        )
+        assert response.status_code == 200
+
+        content = response.json()
+        assert content["id"] == product_id
+        assert content["registration_number"] == product.registration_number
+        assert content["brand_name_en"] == product.brand_name_en
+        assert content["brand_name_fr"] == product.brand_name_fr
+        assert content["name_en"] == product.name_en
+        assert content["name_fr"] == product.name_fr
+
+    def test_product_not_found(
+        self,
+        client: TestClient,
+        db: Session,
+    ) -> None:
+        """Test reading a non-existent product by ID."""
+        user = UserFactory()
+        headers = authentication_token_from_email(
+            client=client, email=user.email, db=db
+        )
+        non_existent_product_id = "123e4567-e89b-12d3-a456-426614174000"
+        response = client.get(
+            f"{settings.API_V1_STR}/products/{non_existent_product_id}",
+            headers=headers,
+        )
+        assert response.status_code == 404
+        content = response.json()
+        assert content["detail"] == "Product not found"
+
+    def test_auth_required_for_reading_by_id(
+        self,
+        client: TestClient,
+        db: Session,
+    ) -> None:
+        """Test that authentication is required for reading product by ID."""
+        user = UserFactory()
+        product = ProductFactory(created_by=user)
+        product_id = str(product.id)
+        response = client.get(
+            f"{settings.API_V1_STR}/products/{product_id}",
+            headers={},
+        )
+        assert response.status_code == 401


### PR DESCRIPTION
## Summary

Implementation to read a product by its ID, and verification of the read_products implementation, which allows filtering by the product’s registration_number to retrieve a list. 

## Changes

### Backend

- Add route to get a product by its ID
- Add test suite and all test pass
- Verify route for read products 
- Verify the method to filter products
- Verify test suite of read products
- Modify a method of controller product to get a product by its ID

> [!NOTE]
> The filter will be further refined in next issue because now the filter can filtered only ```product_type``` and ```registration_number```
