### PR TITLE
Check Azure OpenAI reachability during backend prestart

### DIFF
--- a/backend/app/backend_pre_start.py
+++ b/backend/app/backend_pre_start.py
@@ -1,4 +1,8 @@
+import json
 import logging
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
 
 import boto3
 from sqlalchemy import text
@@ -53,10 +57,62 @@ def check_storage() -> None:
     s3_client.list_buckets()
 
 
+def check_llm() -> None:
+    """Check Azure OpenAI reachability without making a completion request."""
+    endpoint = (settings.AZURE_OPENAI_ENDPOINT or "").rstrip("/")
+    api_key = settings.AZURE_OPENAI_API_KEY
+    api_version = settings.AZURE_OPENAI_API_VERSION
+    deployment_name = settings.AZURE_OPENAI_MODEL
+
+    if not endpoint or api_key is None or not deployment_name:
+        raise RuntimeError(
+            "Azure OpenAI is not configured: AZURE_OPENAI_ENDPOINT, "
+            "AZURE_OPENAI_API_KEY, and AZURE_OPENAI_MODEL are required"
+        )
+
+    query = urlencode({"api-version": api_version})
+    request = Request(
+        f"{endpoint}/openai/deployments?{query}",
+        headers={"api-key": api_key.get_secret_value()},
+        method="GET",
+    )
+    try:
+        with urlopen(request, timeout=10) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace").strip()
+        detail = f": {body}" if body else ""
+        raise RuntimeError(
+            f"Azure OpenAI reachability check failed: HTTP {exc.code} {exc.reason}{detail}"
+        ) from exc
+    except OSError as exc:
+        raise RuntimeError(f"Azure OpenAI reachability check failed: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            "Azure OpenAI reachability check failed: deployments response was not valid JSON"
+        ) from exc
+
+    deployments = payload.get("data")
+    if not isinstance(deployments, list):
+        raise RuntimeError(
+            "Azure OpenAI reachability check failed: deployments response did not contain a data list"
+        )
+
+    if not any(
+        isinstance(deployment, dict)
+        and deployment_name in (deployment.get("id"), deployment.get("model"))
+        for deployment in deployments
+    ):
+        raise RuntimeError(
+            f"Azure OpenAI reachability check failed: deployment '{deployment_name}' was not found"
+        )
+
+
 def main() -> None:
     logger.info("Checking service connectivity")
     check_db()
     check_storage()
+    check_llm()
     logger.info("Service connectivity checks complete")
 
 

--- a/backend/tests/test_backend_pre_start.py
+++ b/backend/tests/test_backend_pre_start.py
@@ -1,8 +1,14 @@
 """Backend pre-start tests."""
 
+from io import BytesIO
 from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError
 
-from app.backend_pre_start import check_db, check_storage, logger, main
+import pytest
+from pydantic import SecretStr
+
+from app.backend_pre_start import check_db, check_llm, check_storage, logger, main
+from app.config import settings
 
 
 def test_check_db_successful_connection() -> None:
@@ -31,11 +37,91 @@ def test_check_storage_connectivity() -> None:
         s3_client_mock.list_buckets.assert_called_once()
 
 
+def test_check_llm_reachability() -> None:
+    """Test Azure OpenAI reachability check lists deployments."""
+    response_mock = MagicMock()
+    response_mock.__enter__.return_value = response_mock
+    response_mock.__exit__.return_value = None
+    response_mock.read.return_value = b'{"data":[{"id":"gpt-4o"}]}'
+
+    with (
+        patch.object(
+            settings, "AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com"
+        ),
+        patch.object(settings, "AZURE_OPENAI_API_KEY", SecretStr("test-key")),
+        patch.object(settings, "AZURE_OPENAI_API_VERSION", "2024-02-15-preview"),
+        patch.object(settings, "AZURE_OPENAI_MODEL", "gpt-4o"),
+        patch(
+            "app.backend_pre_start.urlopen", return_value=response_mock
+        ) as urlopen_mock,
+    ):
+        check_llm()
+
+    request = urlopen_mock.call_args.args[0]
+    assert request.full_url == (
+        "https://example.openai.azure.com/openai/deployments"
+        "?api-version=2024-02-15-preview"
+    )
+    assert request.headers["Api-key"] == "test-key"
+
+
+def test_check_llm_missing_config() -> None:
+    """Test missing Azure OpenAI settings fail prestart clearly."""
+    with (
+        patch.object(settings, "AZURE_OPENAI_ENDPOINT", None),
+        patch.object(settings, "AZURE_OPENAI_API_KEY", None),
+        pytest.raises(RuntimeError, match="Azure OpenAI is not configured"),
+    ):
+        check_llm()
+
+
+def test_check_llm_missing_deployment() -> None:
+    """Test missing Azure OpenAI deployment fails prestart clearly."""
+    response_mock = MagicMock()
+    response_mock.__enter__.return_value = response_mock
+    response_mock.__exit__.return_value = None
+    response_mock.read.return_value = b'{"data":[{"id":"other-deployment"}]}'
+
+    with (
+        patch.object(
+            settings, "AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com"
+        ),
+        patch.object(settings, "AZURE_OPENAI_API_KEY", SecretStr("test-key")),
+        patch.object(settings, "AZURE_OPENAI_MODEL", "gpt-4o"),
+        patch("app.backend_pre_start.urlopen", return_value=response_mock),
+        pytest.raises(RuntimeError, match="deployment 'gpt-4o' was not found"),
+    ):
+        check_llm()
+
+
+def test_check_llm_http_error() -> None:
+    """Test Azure OpenAI HTTP errors identify the failing dependency."""
+    error = HTTPError(
+        url="https://example.openai.azure.com/openai/deployments",
+        code=401,
+        msg="Unauthorized",
+        hdrs=None,
+        fp=BytesIO(b'{"error":"bad key"}'),
+    )
+
+    with (
+        patch.object(
+            settings, "AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com"
+        ),
+        patch.object(settings, "AZURE_OPENAI_API_KEY", SecretStr("test-key")),
+        patch.object(settings, "AZURE_OPENAI_MODEL", "gpt-4o"),
+        patch("app.backend_pre_start.urlopen", side_effect=error),
+        pytest.raises(RuntimeError, match="Azure OpenAI reachability check failed"),
+    ):
+        check_llm()
+
+
 def test_main() -> None:
     """Test main function."""
     with (
         patch("app.backend_pre_start.check_db"),
         patch("app.backend_pre_start.check_storage"),
+        patch("app.backend_pre_start.check_llm"),
         patch.object(logger, "info") as mock_info,
     ):
         main()


### PR DESCRIPTION
## Summary
- add a zero-token Azure OpenAI deployments probe to backend prestart
- fail fast when Azure OpenAI config is missing, unreachable, invalid, or the configured deployment is absent
- wire the LLM check into the existing DB/storage prestart sequence
- add mocked prestart coverage for success and clear failure modes

Fixes #678

## Verification
- `uv run pytest tests/test_backend_pre_start.py` with minimal backend test env (7 passed)
- `uv run ruff check app/backend_pre_start.py tests/test_backend_pre_start.py`
- `uv run ruff format --check app/backend_pre_start.py tests/test_backend_pre_start.py`
- `git diff --check`
