### PR TITLE
682 Route users to extraction

### DIFF
--- a/frontend/src/routes/_layout/$productType/labels/new.tsx
+++ b/frontend/src/routes/_layout/$productType/labels/new.tsx
@@ -201,7 +201,7 @@ function NewLabel() {
                       productType,
                       (labelId) => {
                         navigate({
-                          to: "/$productType/labels/$labelId/files",
+                          to: "/$productType/labels/$labelId/edit",
                           params: { productType, labelId },
                         })
                       },


### PR DESCRIPTION
---
#682 Route users to extraction after upload
---

## Summary

Uploading a new label no longer redirects to the /files endpoint but directly to the /edit one to make extraction more instinctive

## Changes

frontend/src/routes/_layout/$productType/labels/new.tsx:204
```ts
- to: "/$productType/labels/$labelId/files",
+ to: "/$productType/labels/$labelId/edit",
```