### PR TITLE
668 hierarchical durable provision citations

### DIFF
--- a/backend/alembic/versions/9a74c1607706_initial_migration.py
+++ b/backend/alembic/versions/9a74c1607706_initial_migration.py
@@ -1,8 +1,8 @@
 """initial_migration
 
-Revision ID: d9856ad106c5
+Revision ID: 9a74c1607706
 Revises: 
-Create Date: 2026-05-18 16:19:18.614279
+Create Date: 2026-05-18 17:09:37.172712
 
 """
 from typing import Sequence, Union
@@ -13,7 +13,7 @@ import sqlmodel
 
 
 # revision identifiers, used by Alembic.
-revision: str = 'd9856ad106c5'
+revision: str = '9a74c1607706'
 down_revision: Union[str, Sequence[str], None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/alembic/versions/d9856ad106c5_initial_migration.py
+++ b/backend/alembic/versions/d9856ad106c5_initial_migration.py
@@ -1,8 +1,8 @@
-"""initial migration
+"""initial_migration
 
 Revision ID: d9856ad106c5
 Revises: 
-Create Date: 2026-03-19 16:25:51.080895
+Create Date: 2026-05-18 16:19:18.614279
 
 """
 from typing import Sequence, Union
@@ -65,6 +65,9 @@ def upgrade() -> None:
     sa.Column('source_url_en', sqlmodel.sql.sqltypes.AutoString(length=500), nullable=True),
     sa.Column('source_url_fr', sqlmodel.sql.sqltypes.AutoString(length=500), nullable=True),
     sa.Column('last_amended_date', sa.Date(), nullable=True),
+    sa.Column('akn_uri_base', sqlmodel.sql.sqltypes.AutoString(length=500), nullable=True),
+    sa.Column('short_title_en', sqlmodel.sql.sqltypes.AutoString(length=255), nullable=True),
+    sa.Column('short_title_fr', sqlmodel.sql.sqltypes.AutoString(length=255), nullable=True),
     sa.ForeignKeyConstraint(['product_type_id'], ['producttype.id'], name=op.f('fk_legislation_product_type_id_producttype')),
     sa.PrimaryKeyConstraint('id', name=op.f('pk_legislation'))
     )
@@ -133,15 +136,27 @@ def upgrade() -> None:
     sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
     sa.Column('id', sa.Uuid(), nullable=False),
     sa.Column('legislation_id', sa.Uuid(), nullable=False),
-    sa.Column('citation', sqlmodel.sql.sqltypes.AutoString(length=255), nullable=False),
-    sa.Column('text_en', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
-    sa.Column('text_fr', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+    sa.Column('parent_id', sa.Uuid(), nullable=True),
+    sa.Column('section', sqlmodel.sql.sqltypes.AutoString(length=50), nullable=False),
+    sa.Column('subsection', sqlmodel.sql.sqltypes.AutoString(length=50), nullable=True),
+    sa.Column('paragraph', sqlmodel.sql.sqltypes.AutoString(length=10), nullable=True),
+    sa.Column('citation', sa.String(length=50), sa.Computed("section || CASE WHEN subsection IS NOT NULL THEN '(' || subsection || ')' ELSE '' END || CASE WHEN paragraph  IS NOT NULL THEN '(' || paragraph  || ')' ELSE '' END", persisted=True), nullable=True),
+    sa.Column('akn_uri', sqlmodel.sql.sqltypes.AutoString(length=500), nullable=True),
+    sa.Column('superseded_by_id', sa.Uuid(), nullable=True),
+    sa.Column('effective_date', sa.Date(), nullable=True),
+    sa.Column('is_current', sa.Boolean(), nullable=False),
+    sa.Column('text_en', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+    sa.Column('text_fr', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
     sa.Column('is_general_exemption', sa.Boolean(), nullable=False),
     sa.ForeignKeyConstraint(['legislation_id'], ['legislation.id'], name=op.f('fk_provision_legislation_id_legislation')),
+    sa.ForeignKeyConstraint(['parent_id'], ['provision.id'], name=op.f('fk_provision_parent_id_provision')),
+    sa.ForeignKeyConstraint(['superseded_by_id'], ['provision.id'], name=op.f('fk_provision_superseded_by_id_provision')),
     sa.PrimaryKeyConstraint('id', name=op.f('pk_provision'))
     )
+    op.create_index(op.f('ix_provision_akn_uri'), 'provision', ['akn_uri'], unique=True)
     op.create_index(op.f('ix_provision_citation'), 'provision', ['citation'], unique=True)
     op.create_index(op.f('ix_provision_legislation_id'), 'provision', ['legislation_id'], unique=False)
+    op.create_index(op.f('ix_provision_parent_id'), 'provision', ['parent_id'], unique=False)
     op.create_table('requirement',
     sa.Column('guidance_en', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
     sa.Column('guidance_fr', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
@@ -331,8 +346,10 @@ def downgrade() -> None:
     op.drop_table('fertilizerlabeldata')
     op.drop_index(op.f('ix_requirement_legislation_id'), table_name='requirement')
     op.drop_table('requirement')
+    op.drop_index(op.f('ix_provision_parent_id'), table_name='provision')
     op.drop_index(op.f('ix_provision_legislation_id'), table_name='provision')
     op.drop_index(op.f('ix_provision_citation'), table_name='provision')
+    op.drop_index(op.f('ix_provision_akn_uri'), table_name='provision')
     op.drop_table('provision')
     op.drop_index(op.f('ix_label_review_status'), table_name='label')
     op.drop_index(op.f('ix_label_product_type_id'), table_name='label')

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -1,7 +1,9 @@
 """Database initialization utilities."""
 
 import logging
+import re
 from typing import Any
+from uuid import UUID
 
 from sqlmodel import Session, select
 
@@ -157,50 +159,164 @@ def _seed_definitions(
             session.flush()
 
 
+CITATION_RE = re.compile(r"^([\d.]+)(?:\(([\d.]+)\))?(?:\(([^)]+)\))?$")
+
+# Canonical AKN URI bases — extend as new legislation is added
+AKN_URI_MAP = {
+    "C.R.C., c. 666": "/akn/ca/reg/fertilizers-regulations",
+    "C.R.C., c. 296": "/akn/ca/reg/feeds-regulations",
+    "R.S.C., 1985, c. F-10": "/akn/ca/act/fertilizers-act",
+}
+
+def _get_or_create_provision(
+    session: Session,
+    legislation_id: UUID,
+    section: str,
+    subsection: str | None,
+    paragraph: str | None,
+    akn_base: str | None,
+    extra: dict | None = None,
+) -> Provision:
+    prov = session.exec(
+        select(Provision).where(
+            Provision.legislation_id == legislation_id,
+            Provision.section == section,
+            Provision.subsection == subsection,
+            Provision.paragraph == paragraph,
+        )
+    ).first()
+
+    if not prov:
+        akn_uri = _build_akn_uri(akn_base, section, subsection, paragraph) if akn_base else None
+        data = {
+            "legislation_id": legislation_id,
+            "section": section,
+            "subsection": subsection,
+            "paragraph": paragraph,
+            "akn_uri": akn_uri,
+            "is_current": True,
+            **(extra or {}),
+        }
+        prov = Provision(**data)
+        session.add(prov)
+        session.flush()
+        logger.info(f"Provision created: {prov.citation} (phantom={extra is None})")
+    elif extra:
+        for k, v in extra.items():
+            if k == "akn_uri" and prov.akn_uri is not None:
+                continue
+            setattr(prov, k, v)
+        session.add(prov)
+        session.flush()
+
+    return prov
+
+def _parse_citation(citation: str) -> tuple[str, str | None, str | None]:
+    m = CITATION_RE.match(citation)
+    if not m:
+        raise ValueError(f"Unrecognized citation format: {citation!r}")
+    section, subsection, paragraph = m.groups()
+    return section, subsection, paragraph
+
+
+def _build_akn_uri(akn_base: str, section: str, subsection: str | None, paragraph: str | None) -> str:
+    uri = f"{akn_base}/section/{section}"
+    if subsection:
+        uri += f"/subsection/{subsection}"
+    if paragraph:
+        uri += f"/paragraph/{paragraph}"
+    return uri
+
 def _seed_provisions(
     session: Session,
     seed_data: dict[str, Any],
     leg_map: dict[str, Legislation],
 ) -> None:
-    for prov_data in seed_data.get(SEED_PROVISIONS, []):
+    provisions_data = seed_data.get(SEED_PROVISIONS, [])
+
+    # Sort by depth so parents are always created before children
+    def _depth(citation: str) -> int:
+        m = CITATION_RE.match(citation)
+        if not m:
+            return 1
+        _, sub, par = m.groups()
+        if par:
+            return 3
+        if sub:
+            return 2
+        return 1
+
+    sorted_provisions = sorted(
+        provisions_data,
+        key=lambda p: _depth(p.get(KEY_CITATION, ""))
+    )
+
+    for prov_data in sorted_provisions:
         leg_ref = prov_data.get(KEY_LEGISLATION_CITATION)
+        raw_citation = prov_data.get(KEY_CITATION, "")
+        logger.info(f"Processing provision: {raw_citation}")
+
         leg = leg_map.get(leg_ref)
         if not leg:
-            logger.error(
-                f"Legislation {leg_ref} not found for provision {prov_data.get(KEY_CITATION, '')}"
-            )
+            logger.error(f"Legislation {leg_ref} not found for provision {raw_citation}")
             continue
+
+        try:
+            section, subsection, paragraph = _parse_citation(raw_citation)
+        except ValueError as e:
+            logger.error(str(e))
+            continue
+
+        akn_base = AKN_URI_MAP.get(leg_ref)
         def_infos = prov_data.get(KEY_DEFINITIONS, [])
-        model_data = {
+        extra = {
             k: v
             for k, v in prov_data.items()
-            if k not in (KEY_LEGISLATION_CITATION, KEY_DEFINITIONS)
+            if k not in (KEY_LEGISLATION_CITATION, KEY_DEFINITIONS, KEY_CITATION)
         }
-        prov = session.exec(
-            select(Provision).where(
-                Provision.legislation_id == leg.id,
-                Provision.citation == prov_data[KEY_CITATION],
+        extra |= {"section": section, "subsection": subsection, "paragraph": paragraph}
+
+        # Synthesize phantom parents if they don't exist yet
+        section_row: Provision | None = None
+        subsection_row: Provision | None = None
+
+        # Always ensure section row exists
+        section_row = _get_or_create_provision(
+            session, leg.id, section, None, None, akn_base
+        )
+
+        # Ensure subsection row exists if this provision has a subsection
+        if subsection:
+            subsection_row = _get_or_create_provision(
+                session, leg.id, section, subsection, None, akn_base
             )
-        ).first()
-        if not prov:
-            prov = Provision(legislation_id=leg.id, **model_data)
-            session.add(prov)
+            subsection_row.parent_id = section_row.id
+            session.add(subsection_row)
             session.flush()
-            logger.info(f"Provision created: {prov.citation}")
+
+        # Resolve parent_id for the actual provision
+        if paragraph:
+            parent_id = subsection_row.id if subsection_row else None
+        elif subsection:
+            parent_id = section_row.id
         else:
-            for k, v in model_data.items():
-                setattr(prov, k, v)
-            session.add(prov)
-            session.flush()
+            parent_id = None
+
+        # Create or update the actual provision
+        extra["parent_id"] = parent_id
+        prov = _get_or_create_provision(
+            session, leg.id, section, subsection, paragraph, akn_base, extra
+        )
+
+        # Link definitions
         for def_info in def_infos:
             def_leg_ref = def_info[KEY_LEGISLATION]
             term = def_info[KEY_TERM]
             target_leg = leg_map.get(def_leg_ref)
             if not target_leg:
-                logger.error(
-                    f"Legislation {def_leg_ref} not found for definition {term}"
-                )
+                logger.error(f"Legislation {def_leg_ref} not found for definition {term}")
                 continue
+
             definition = session.exec(
                 select(Definition).where(
                     Definition.legislation_id == target_leg.id,
@@ -209,6 +325,7 @@ def _seed_provisions(
             ).first()
             if not definition:
                 continue
+
             exists = session.exec(
                 select(ProvisionDefinition).where(
                     ProvisionDefinition.provision_id == prov.id,
@@ -216,12 +333,7 @@ def _seed_provisions(
                 )
             ).first()
             if not exists:
-                session.add(
-                    ProvisionDefinition(
-                        provision_id=prov.id, definition_id=definition.id
-                    )
-                )
-
+                session.add(ProvisionDefinition(provision_id=prov.id, definition_id=definition.id))
 
 def _seed_requirements(
     session: Session,

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -168,6 +168,7 @@ AKN_URI_MAP = {
     "R.S.C., 1985, c. F-10": "/akn/ca/act/fertilizers-act",
 }
 
+
 def _get_or_create_provision(
     session: Session,
     legislation_id: UUID,
@@ -187,7 +188,11 @@ def _get_or_create_provision(
     ).first()
 
     if not prov:
-        akn_uri = _build_akn_uri(akn_base, section, subsection, paragraph) if akn_base else None
+        akn_uri = (
+            _build_akn_uri(akn_base, section, subsection, paragraph)
+            if akn_base
+            else None
+        )
         data = {
             "legislation_id": legislation_id,
             "section": section,
@@ -211,6 +216,7 @@ def _get_or_create_provision(
 
     return prov
 
+
 def _parse_citation(citation: str) -> tuple[str, str | None, str | None]:
     m = CITATION_RE.match(citation)
     if not m:
@@ -219,13 +225,16 @@ def _parse_citation(citation: str) -> tuple[str, str | None, str | None]:
     return section, subsection, paragraph
 
 
-def _build_akn_uri(akn_base: str, section: str, subsection: str | None, paragraph: str | None) -> str:
+def _build_akn_uri(
+    akn_base: str, section: str, subsection: str | None, paragraph: str | None
+) -> str:
     uri = f"{akn_base}/section/{section}"
     if subsection:
         uri += f"/subsection/{subsection}"
     if paragraph:
         uri += f"/paragraph/{paragraph}"
     return uri
+
 
 def _seed_provisions(
     session: Session,
@@ -247,8 +256,7 @@ def _seed_provisions(
         return 1
 
     sorted_provisions = sorted(
-        provisions_data,
-        key=lambda p: _depth(p.get(KEY_CITATION, ""))
+        provisions_data, key=lambda p: _depth(p.get(KEY_CITATION, ""))
     )
 
     for prov_data in sorted_provisions:
@@ -258,7 +266,9 @@ def _seed_provisions(
 
         leg = leg_map.get(leg_ref)
         if not leg:
-            logger.error(f"Legislation {leg_ref} not found for provision {raw_citation}")
+            logger.error(
+                f"Legislation {leg_ref} not found for provision {raw_citation}"
+            )
             continue
 
         try:
@@ -314,7 +324,9 @@ def _seed_provisions(
             term = def_info[KEY_TERM]
             target_leg = leg_map.get(def_leg_ref)
             if not target_leg:
-                logger.error(f"Legislation {def_leg_ref} not found for definition {term}")
+                logger.error(
+                    f"Legislation {def_leg_ref} not found for definition {term}"
+                )
                 continue
 
             definition = session.exec(
@@ -333,7 +345,12 @@ def _seed_provisions(
                 )
             ).first()
             if not exists:
-                session.add(ProvisionDefinition(provision_id=prov.id, definition_id=definition.id))
+                session.add(
+                    ProvisionDefinition(
+                        provision_id=prov.id, definition_id=definition.id
+                    )
+                )
+
 
 def _seed_requirements(
     session: Session,

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -175,7 +175,7 @@ def _get_or_create_provision(
     subsection: str | None,
     paragraph: str | None,
     akn_base: str | None,
-    extra: dict | None = None,
+    extra: dict[str, Any] | None = None,
 ) -> Provision:
     prov = session.exec(
         select(Provision).where(

--- a/backend/app/db/models/legislation.py
+++ b/backend/app/db/models/legislation.py
@@ -21,6 +21,9 @@ class Legislation(Base, TimestampMixin, DescriptiveMixin, GuidanceMixin, table=T
     source_url_en: str | None = Field(default=None, max_length=500)
     source_url_fr: str | None = Field(default=None, max_length=500)
     last_amended_date: date | None = Field(default=None)
+    akn_uri_base: str | None = Field(default=None, nullable=True, max_length=500)
+    short_title_en: str | None = Field(default=None, nullable=True, max_length=255)
+    short_title_fr: str | None = Field(default=None, nullable=True, max_length=255)
 
     provisions: list["Provision"] = Relationship(
         back_populates="legislation", cascade_delete=True

--- a/backend/app/db/models/provision.py
+++ b/backend/app/db/models/provision.py
@@ -53,7 +53,9 @@ class Provision(Base, TimestampMixin, DescriptiveMixin, GuidanceMixin, table=Tru
     )
 
     # Stable AKN URI — set once at insert, never updated
-    akn_uri: str | None = Field(default=None, nullable=True, max_length=500, unique=True, index=True)
+    akn_uri: str | None = Field(
+        default=None, nullable=True, max_length=500, unique=True, index=True
+    )
 
     # Amendment tracking
     superseded_by_id: UUID | None = Field(

--- a/backend/app/db/models/provision.py
+++ b/backend/app/db/models/provision.py
@@ -1,9 +1,11 @@
 from datetime import date
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
+
 from sqlalchemy import Column, Computed, String
 from sqlalchemy.orm import relationship
 from sqlmodel import Field, Relationship
+
 from app.db.base import Base, DescriptiveMixin, GuidanceMixin, TimestampMixin
 
 if TYPE_CHECKING:
@@ -77,17 +79,17 @@ class Provision(Base, TimestampMixin, DescriptiveMixin, GuidanceMixin, table=Tru
 # Self-referential relationships must be defined outside the class in SQLModel
 Provision.parent = relationship(
     "Provision",
-    foreign_keys=[Provision.parent_id],
-    remote_side=[Provision.id],
+    foreign_keys="[Provision.parent_id]",
+    remote_side="[Provision.id]",
     back_populates="children",
 )
 Provision.children = relationship(
     "Provision",
-    foreign_keys=[Provision.parent_id],
+    foreign_keys="[Provision.parent_id]",
     back_populates="parent",
 )
 Provision.superseded_by = relationship(
     "Provision",
-    foreign_keys=[Provision.superseded_by_id],
-    remote_side=[Provision.id],
+    foreign_keys="[Provision.superseded_by_id]",
+    remote_side="[Provision.id]",
 )

--- a/backend/app/db/models/provision.py
+++ b/backend/app/db/models/provision.py
@@ -1,8 +1,9 @@
+from datetime import date
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
-
+from sqlalchemy import Column, Computed, String
+from sqlalchemy.orm import relationship
 from sqlmodel import Field, Relationship
-
 from app.db.base import Base, DescriptiveMixin, GuidanceMixin, TimestampMixin
 
 if TYPE_CHECKING:
@@ -19,13 +20,74 @@ class ProvisionDefinition(Base, TimestampMixin, table=True):
 class Provision(Base, TimestampMixin, DescriptiveMixin, GuidanceMixin, table=True):
     id: UUID = Field(default_factory=uuid4, primary_key=True)
     legislation_id: UUID = Field(foreign_key="legislation.id", index=True)
-    citation: str = Field(max_length=255, unique=True, index=True)
-    text_en: str
-    text_fr: str
+
+    # Hierarchy
+    parent_id: UUID | None = Field(
+        default=None,
+        foreign_key="provision.id",
+        nullable=True,
+        index=True,
+    )
+
+    # Citation components
+    section: str = Field(nullable=False, max_length=50)
+    subsection: str | None = Field(default=None, nullable=True, max_length=50)
+    paragraph: str | None = Field(default=None, nullable=True, max_length=10)
+
+    # Generated display citation
+    citation: str | None = Field(
+        default=None,
+        sa_column=Column(
+            String(50),
+            Computed(
+                "section"
+                " || CASE WHEN subsection IS NOT NULL THEN '(' || subsection || ')' ELSE '' END"
+                " || CASE WHEN paragraph  IS NOT NULL THEN '(' || paragraph  || ')' ELSE '' END",
+                persisted=True,
+            ),
+            unique=True,
+            index=True,
+        ),
+    )
+
+    # Stable AKN URI — set once at insert, never updated
+    akn_uri: str | None = Field(default=None, nullable=True, max_length=500, unique=True, index=True)
+
+    # Amendment tracking
+    superseded_by_id: UUID | None = Field(
+        default=None,
+        foreign_key="provision.id",
+        nullable=True,
+    )
+    effective_date: date | None = Field(default=None, nullable=True)
+    is_current: bool = Field(default=True)
+
+    text_en: str | None = Field(default=None, nullable=True)
+    text_fr: str | None = Field(default=None, nullable=True)
     is_general_exemption: bool = Field(default=False)
 
+    # Relationships
     legislation: "Legislation" = Relationship(back_populates="provisions")
     definitions: list["Definition"] = Relationship(
         link_model=ProvisionDefinition,
         sa_relationship_kwargs={"lazy": "selectin"},
     )
+
+
+# Self-referential relationships must be defined outside the class in SQLModel
+Provision.parent = relationship(
+    "Provision",
+    foreign_keys=[Provision.parent_id],
+    remote_side=[Provision.id],
+    back_populates="children",
+)
+Provision.children = relationship(
+    "Provision",
+    foreign_keys=[Provision.parent_id],
+    back_populates="parent",
+)
+Provision.superseded_by = relationship(
+    "Provision",
+    foreign_keys=[Provision.superseded_by_id],
+    remote_side=[Provision.id],
+)

--- a/backend/app/services/compliance.py
+++ b/backend/app/services/compliance.py
@@ -50,7 +50,7 @@ def get_general_exemptions(requirement: Requirement) -> str:
 
     # Sort for deterministic output
     sorted_provisions = sorted(
-        requirement.legislation.general_exemptions, key=lambda p: p.citation
+        requirement.legislation.general_exemptions, key=lambda p: p.citation or ""
     )
     lines = [f"- {p.citation}: {p.text_en}" for p in sorted_provisions]
     return "\n".join(lines)
@@ -66,7 +66,7 @@ def get_exemptions(requirement: Requirement) -> str:
     ]
     if not exemptions:
         return ""
-    sorted_provisions = sorted(exemptions, key=lambda p: p.citation)
+    sorted_provisions = sorted(exemptions, key=lambda p: p.citation or "")
     lines = [f"- {p.citation}: {p.text_en}" for p in sorted_provisions]
     return "\n".join(lines)
 
@@ -83,7 +83,7 @@ def get_applicability_conditions(requirement: Requirement) -> str:
     ]
     if not conditions:
         return ""
-    sorted_provisions = sorted(conditions, key=lambda p: p.citation)
+    sorted_provisions = sorted(conditions, key=lambda p: p.citation or "")
     lines = [f"- {p.citation}: {p.text_en}" for p in sorted_provisions]
     return "\n".join(lines)
 
@@ -95,7 +95,7 @@ def get_requirement_provisions(requirement: Requirement) -> str:
     """
     if not requirement.provisions:
         return ""
-    sorted_provisions = sorted(requirement.provisions, key=lambda p: p.citation)
+    sorted_provisions = sorted(requirement.provisions, key=lambda p: p.citation or "")
     lines = [f"- {p.citation}: {p.text_en}" for p in sorted_provisions]
     if requirement.guidance_en:
         lines.append(f"\nGuidance: {requirement.guidance_en}")

--- a/backend/tests/factories/provision.py
+++ b/backend/tests/factories/provision.py
@@ -1,5 +1,5 @@
+import uuid
 import factory
-
 from app.db.models.provision import Provision
 from tests.factories import BaseFactory
 
@@ -10,7 +10,10 @@ class ProvisionFactory(BaseFactory):
 
     legislation = factory.SubFactory("tests.factories.legislation.LegislationFactory")
     legislation_id = factory.LazyAttribute(lambda obj: obj.legislation.id)
-    citation = factory.Sequence(lambda n: f"Section {n}")
+    section = factory.LazyFunction(lambda: uuid.uuid4().hex)
+    subsection = None
+    paragraph = None
     text_en = factory.Faker("paragraph")
     text_fr = factory.Faker("paragraph")
     is_general_exemption = False
+    is_current = True

--- a/backend/tests/factories/provision.py
+++ b/backend/tests/factories/provision.py
@@ -1,5 +1,7 @@
 import uuid
+
 import factory
+
 from app.db.models.provision import Provision
 from tests.factories import BaseFactory
 

--- a/backend/tests/test_services/test_compliance.py
+++ b/backend/tests/test_services/test_compliance.py
@@ -156,7 +156,7 @@ class TestGetGeneralExemptions:
             legislation=requirement.legislation,
             text_en="Exemption A",
             is_general_exemption=True,
-            citation="Global-1",
+            section="Global-1",
         )
         db.flush()
         db.refresh(requirement.legislation)
@@ -169,13 +169,13 @@ class TestGetGeneralExemptions:
         requirement = RequirementFactory.create()
         ProvisionFactory.create(
             legislation=requirement.legislation,
-            citation="B",
+            section="B",
             text_en="Exemption B",
             is_general_exemption=True,
         )
         ProvisionFactory.create(
             legislation=requirement.legislation,
-            citation="A",
+            section="A",
             text_en="Exemption A",
             is_general_exemption=True,
         )
@@ -191,13 +191,13 @@ class TestGetGeneralExemptions:
         requirement = RequirementFactory.create()
         ProvisionFactory.create(
             legislation=requirement.legislation,
-            citation="Global-A",
+            section="Global-A",
             text_en="Exemption A",
             is_general_exemption=True,
         )
         ProvisionFactory.create(
             legislation=requirement.legislation,
-            citation="Regular-A",
+            section="Regular-A",
             text_en="Standard Rule",
             is_general_exemption=False,
         )
@@ -229,11 +229,11 @@ class TestRequirementModifiers:
         """Test fetching correctly by type using the explicit relationships."""
         requirement = RequirementFactory.create()
         exemption_prov = ProvisionFactory.create(
-            legislation=requirement.legislation, citation="Ex-1", text_en="Exemption A"
+            legislation=requirement.legislation, section="Ex-1", text_en="Exemption A"
         )
         condition_prov = ProvisionFactory.create(
             legislation=requirement.legislation,
-            citation="Cond-1",
+            section="Cond-1",
             text_en="Condition A",
         )
 
@@ -260,10 +260,10 @@ class TestRequirementModifiers:
         """Test that multiple modifiers of the same type are sorted by citation."""
         requirement = RequirementFactory.create()
         ex_b = ProvisionFactory.create(
-            legislation=requirement.legislation, citation="B", text_en="Exemption B"
+            legislation=requirement.legislation, section="B", text_en="Exemption B"
         )
         ex_a = ProvisionFactory.create(
-            legislation=requirement.legislation, citation="A", text_en="Exemption A"
+            legislation=requirement.legislation, section="A", text_en="Exemption A"
         )
 
         RequirementModifierFactory.create(
@@ -296,12 +296,12 @@ class TestGetRequirementProvisions:
         requirement = RequirementFactory.create(guidance_en="")
         p_b = ProvisionFactory.create(
             legislation=requirement.legislation,
-            citation="Provision-B",
+            section="Provision-B",
             text_en="Text B",
         )
         p_a = ProvisionFactory.create(
             legislation=requirement.legislation,
-            citation="Provision-A",
+            section="Provision-A",
             text_en="Text A",
         )
         requirement.provisions.append(p_b)
@@ -365,13 +365,13 @@ class TestBuildContext:
         # Add one of each to ensure non-empty strings
         ProvisionFactory.create(
             legislation=requirement.legislation,
-            citation="Global-1",
+            section="Global-1",
             is_general_exemption=True,
             text_en="Global Rule",
         )
         p_req = ProvisionFactory.create(
             legislation=requirement.legislation,
-            citation="Req-1",
+            section="Req-1",
             text_en="Core Requirement",
         )
         requirement.provisions.append(p_req)

--- a/frontend/src/routes/_layout/$productType/labels/new.tsx
+++ b/frontend/src/routes/_layout/$productType/labels/new.tsx
@@ -201,7 +201,7 @@ function NewLabel() {
                       productType,
                       (labelId) => {
                         navigate({
-                          to: "/$productType/labels/$labelId/files",
+                          to: "/$productType/labels/$labelId/edit",
                           params: { productType, labelId },
                         })
                       },


### PR DESCRIPTION
---
#668: Structured provision hierarchy with AKN URI and amendment scaffolding
---

## Summary
Replaces the flat `Provision.citation` string with a structured, queryable hierarchy (section → subsection → paragraph), adds a stable Akoma Ntoso URI scheme, and scaffolds amendment tracking. Seed script now synthesizes phantom parent rows to enable full recursive traversal.

## Changes

### Data Model
- Split `citation` into `section`, `subsection`, `paragraph` columns; retain `citation` as a Postgres generated column for display/backwards compatibility
- Add `parent_id` self-referential FK enabling section → subsection → paragraph tree traversal
- Add `akn_uri` (immutable, set at insert, never overwritten) following `/akn/ca/reg/.../section/.../subsection/.../paragraph/...` scheme
- Add amendment tracking fields: `superseded_by_id`, `effective_date`, `is_current`
- Make `text_en` and `text_fr` nullable to support phantom rows
- Add `akn_uri_base`, `short_title_en`, `short_title_fr` to `Legislation` model

### Database
- Squash all iterative migration files into a single clean `initial_migration`
- Add self-referential relationships for `parent`, `children`, and `superseded_by` via raw SQLAlchemy `relationship()` post-class definition (SQLModel limitation workaround)

### Seed Script
- Extract `_get_or_create_provision` helper for idempotent upserts
- Synthesize phantom section and subsection rows for provisions not explicitly present in JSON, enabling recursive CTE traversal from root
- Parse citation string into components via regex at seed time only; structured fields stored directly
- Add `AKN_URI_MAP` mapping legislation citation references to canonical AKN URI bases
- `akn_uri` is never overwritten on re-seed, preserving stable identity across runs